### PR TITLE
allow PRs to succeed if images can be built

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -31,6 +31,7 @@ jobs:
       uses: docker/setup-buildx-action@v1
 
     - name: Login to DockerHub
+      if: ${{ github.event_name != 'pull_request' }}
       uses: docker/login-action@v1
       with:
         username: ${{ secrets.DOCKER_USERNAME }}
@@ -39,6 +40,6 @@ jobs:
     - name: Build and push
       uses: docker/build-push-action@v2
       with:
-        push: true
+        push: ${{ github.event_name != 'pull_request' }}
         context: ${{ matrix.config.directory }}
         tags: rocker/r-bspm:${{ matrix.config.tag }}


### PR DESCRIPTION
PRs like this cannot access secrets. So for them to be useful (i.e., images are built -> green check), the login and push steps need to be avoided.