### PR TITLE
add Arch-based image

### DIFF
--- a/arch/Dockerfile
+++ b/arch/Dockerfile
@@ -1,0 +1,38 @@
+FROM archlinux:latest
+
+LABEL org.label-schema.license="GPL-2.0" \
+      org.label-schema.vcs-url="https://github.com/rocker-org/bspm" \
+      maintainer="Iñaki Ucar <iucar@fedoraproject.org>"
+
+RUN echo -e "\n[desolve]\nServer = https://desolve.ru/archrepo/\$arch" \
+    >> /etc/pacman.conf \
+    && pacman -Syu --noconfirm \
+        sudo shadow make gcc-fortran \
+        r pyalpm python-{dbus,gobject}
+
+RUN echo "options(repos='https://cloud.r-project.org')" \
+        > /usr/lib64/R/etc/Rprofile.site \
+    && Rscript -e 'install.packages(c("bspm", "littler"))' \
+    && echo "bspm::enable()" >> /usr/lib64/R/etc/Rprofile.site \
+    && echo "options(bspm.sudo=TRUE)" >> /usr/lib64/R/etc/Rprofile.site
+
+RUN useradd -m docker \
+    && echo "docker ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/docker-user \
+    && chmod 0440 /etc/sudoers.d/docker-user \
+    && echo 'R_LIBS_SITE=/usr/local/lib/R/site-library:/usr/lib64/R/library' \
+        >> /usr/lib64/R/etc/Renviron \
+    && mkdir -p /usr/local/lib/R/site-library \
+    && chown 1000:1000 /usr/local/lib/R/site-library
+
+RUN ln -s /usr/lib64/R/library/littler/bin/r /usr/local/bin/r \
+    && ln -s /usr/lib64/R/library/littler/examples/install.r \
+        /usr/local/bin/install.r \
+    && ln -s /usr/lib64/R/library/littler/examples/install2.r \
+        /usr/local/bin/install2.r \
+    && ln -s /usr/lib64/R/library/littler/examples/installGithub.r \
+        /usr/local/bin/installGithub.r \
+    && ln -s /usr/lib64/R/library/littler/examples/testInstalled.r \
+        /usr/local/bin/testInstalled.r \
+    && install.r remotes
+
+CMD ["bash"]


### PR DESCRIPTION
/cc @dvdesolve. Sample output:

```bash
$ docker run --rm -it r-bspm:arch install.r ggplot2
(loaded the methods namespace)
Loading required package: utils
Tracing function "install.packages" in package "utils"
Install system packages as root...
:: Synchronizing package databases...
 core
 extra
 community
 desolve
:: Retrieving packages...
 r-ggplot2-3.3.5-2-any
 r-colorspace-2.0.2-1-x86_64
 r-isoband-0.2.5-1-x86_64
 r-farver-2.1.0-1-x86_64
 r-viridislite-0.4.0-1-any
 r-rlang-0.4.12-1-x86_64
 r-cli-3.1.0-1-x86_64
 r-vctrs-0.3.8-1-x86_64
 r-pillar-1.6.4-1-any
 r-tibble-3.1.6-1-x86_64
 r-scales-1.1.1-1-any
 r-gtable-0.3.0-1-any
 r-munsell-0.5.0-1-any
 r-withr-2.4.3-1-any
 r-fansi-0.5.0-1-x86_64
 r-magrittr-2.0.1-1-x86_64
 r-digest-0.6.29-1-x86_64
 r-crayon-1.4.2-1-any
 r-glue-1.6.0-1-x86_64
 r-utf8-1.2.2-1-x86_64
 r-lifecycle-1.0.1-1-any
 r-r6-2.5.1-1-any
 r-labeling-0.4.2-1-any
 r-rcolorbrewer-1.1.2-1-any
 r-ellipsis-0.3.2-1-x86_64
 r-pkgconfig-2.0.3-1-any
:: Processing package changes...
(1/26) r-digest
(2/26) r-glue
(3/26) r-gtable
(4/26) r-isoband
(5/26) r-rlang
(6/26) r-farver
(7/26) r-labeling
(8/26) r-lifecycle
(9/26) r-colorspace
(10/26) r-munsell
(11/26) r-r6
(12/26) r-rcolorbrewer
(13/26) r-viridislite
(14/26) r-scales
(15/26) r-ellipsis
(16/26) r-fansi
(17/26) r-magrittr
(18/26) r-cli
(19/26) r-crayon
(20/26) r-utf8
(21/26) r-vctrs
(22/26) r-pillar
(23/26) r-pkgconfig
(24/26) r-tibble
(25/26) r-withr
(26/26) r-ggplot2
```