### PR TITLE
update fedora version to 36

### DIFF
--- a/fedora/Dockerfile
+++ b/fedora/Dockerfile
@@ -1,4 +1,4 @@
-FROM fedora:34
+FROM fedora:36
 
 LABEL org.label-schema.license="GPL-2.0" \
       org.label-schema.vcs-url="https://github.com/rocker-org/rocker" \


### PR DESCRIPTION
Sample output from installing `sf` (which requires several system libraries):
```shell
niklas@niklas-desktop ~/s/f/b/fedora (master)> docker run --rm -it fd89
[root@37c3b0aef977 /]# R

R version 4.1.3 (2022-03-10) -- "One Push-Up"
Copyright (C) 2022 The R Foundation for Statistical Computing
Platform: x86_64-redhat-linux-gnu (64-bit)

R is free software and comes with ABSOLUTELY NO WARRANTY.
You are welcome to redistribute it under certain conditions.
Type 'license()' or 'licence()' for distribution details.

R is a collaborative project with many contributors.
Type 'contributors()' for more information and
'citation()' on how to cite R or R packages in publications.

Type 'demo()' for some demos, 'help()' for on-line help, or
'help.start()' for an HTML browser interface to help.
Type 'q()' to quit R.

> install.packages("sf")
Install system packages as root...
(1/68): udunits2-2.2.28-5.fc36.x86_64.rpm                                                                                                                                                              2.5 MB/s | 631 kB     00:00    
(2/68): R-CRAN-Rcpp-1.0.9-1.fc36.copr4633910.x86_64.rpm                                                                                                                                                5.1 MB/s | 2.0 MB     00:00    
(3/68): ogdi-4.1.0-7.fc36.x86_64.rpm                                                                                                                                                                   605 kB/s | 248 kB     00:00    
(4/68): xerces-c-3.2.3-6.fc36.x86_64.rpm                                                                                                                                                               5.1 MB/s | 964 kB     00:00    
(5/68): libgta-1.2.1-7.fc36.x86_64.rpm                                                                                                                                                                 1.1 MB/s |  36 kB     00:00    
(6/68): libdap-3.20.9-2.fc36.x86_64.rpm                                                                                                                                                                6.1 MB/s | 701 kB     00:00    
(7/68): freexl-1.0.6-16.fc36.x86_64.rpm                                                                                                                                                                269 kB/s |  35 kB     00:00    
(8/68): unixODBC-2.3.9-5.fc36.x86_64.rpm                                                                                                                                                               7.4 MB/s | 456 kB     00:00    
(9/68): hdf-libs-4.2.15-9.fc36.x86_64.rpm                                                                                                                                                              4.1 MB/s | 295 kB     00:00    
(10/68): libaec-1.0.6-2.fc36.x86_64.rpm                                                                                                                                                                1.6 MB/s |  41 kB     00:00    
(11/68): minizip-3.0.2-6.fc36.x86_64.rpm                                                                                                                                                               690 kB/s |  70 kB     00:00    
(12/68): hdf5-1.12.1-5.fc36.x86_64.rpm                                                                                                                                                                 9.2 MB/s | 2.2 MB     00:00    
(13/68): jasper-libs-2.0.33-2.fc36.x86_64.rpm                                                                                                                                                          2.4 MB/s | 156 kB     00:00    
(14/68): mariadb-connector-c-3.2.7-1.fc36.x86_64.rpm                                                                                                                                                   7.3 MB/s | 196 kB     00:00    
(15/68): mariadb-connector-c-config-3.2.7-1.fc36.noarch.rpm                                                                                                                                            646 kB/s | 9.5 kB     00:00    
(16/68): geos-3.10.2-4.fc36.x86_64.rpm                                                                                                                                                                 2.3 MB/s | 953 kB     00:00    
(17/68): SuperLU-5.3.0-2.fc36.x86_64.rpm                                                                                                                                                               6.5 MB/s | 189 kB     00:00    
(18/68): R-CRAN-class-7.3.20-1.fc36.copr4235897.x86_64.rpm                                                                                                                                             349 kB/s | 107 kB     00:00    
(19/68): libpq-14.1-2.fc36.x86_64.rpm                                                                                                                                                                  4.4 MB/s | 198 kB     00:00    
(20/68): librttopo-1.1.0-8.fc36.x86_64.rpm                                                                                                                                                             5.4 MB/s | 208 kB     00:00    
(21/68): R-CRAN-KernSmooth-2.23.20-1.fc36.copr4232710.x86_64.rpm                                                                                                                                       230 kB/s | 108 kB     00:00    
(22/68): R-CRAN-classInt-0.4.7-1.fc36.copr4510456.x86_64.rpm                                                                                                                                           629 kB/s | 484 kB     00:00    
(23/68): R-CRAN-e1071-1.7.11-1.fc36.copr4504876.x86_64.rpm                                                                                                                                             1.7 MB/s | 604 kB     00:00    
(24/68): proj-8.2.1-6.fc36.x86_64.rpm                                                                                                                                                                  3.0 MB/s | 1.4 MB     00:00    
(25/68): proj-data-8.2.1-6.fc36.noarch.rpm                                                                                                                                                             1.9 MB/s | 1.2 MB     00:00    
(26/68): proj-data-at-8.2.1-6.fc36.noarch.rpm                                                                                                                                                          6.9 MB/s | 2.1 MB     00:00    
(27/68): gdal-libs-3.4.3-1.fc36.x86_64.rpm                                                                                                                                                             6.6 MB/s | 8.8 MB     00:01    
(28/68): proj-data-be-8.2.1-6.fc36.noarch.rpm                                                                                                                                                          3.9 MB/s | 726 kB     00:00    
(29/68): armadillo-10.8.2-1.fc36.x86_64.rpm                                                                                                                                                            697 kB/s |  35 kB     00:00    
(30/68): proj-data-br-8.2.1-6.fc36.noarch.rpm                                                                                                                                                          5.1 MB/s | 1.0 MB     00:00    
(31/68): libspatialite-5.0.1-12.fc36.x86_64.rpm                                                                                                                                                        5.3 MB/s | 3.6 MB     00:00    
(32/68): proj-data-ch-8.2.1-6.fc36.noarch.rpm                                                                                                                                                          4.8 MB/s | 2.1 MB     00:00    
(33/68): proj-data-de-8.2.1-6.fc36.noarch.rpm                                                                                                                                                          4.6 MB/s |  72 MB     00:15    
(34/68): R-CRAN-magrittr-2.0.3-1.fc36.copr4227992.x86_64.rpm                                                                                                                                           5.3 MB/s | 221 kB     00:00    
(35/68): proj-data-dk-8.2.1-6.fc36.noarch.rpm                                                                                                                                                          4.4 MB/s | 9.7 MB     00:02    
(36/68): arpack-3.8.0-4.fc36.x86_64.rpm                                                                                                                                                                2.1 MB/s | 209 kB     00:00    
(37/68): proj-data-es-8.2.1-6.fc36.noarch.rpm                                                                                                                                                          4.2 MB/s | 1.0 MB     00:00    
(38/68): proj-data-eur-8.2.1-6.fc36.noarch.rpm                                                                                                                                                         3.5 MB/s | 1.0 MB     00:00    
(39/68): proj-data-fi-8.2.1-6.fc36.noarch.rpm                                                                                                                                                          2.0 MB/s |  87 kB     00:00    
(40/68): R-CRAN-proxy-0.4.27-1.fc36.copr4508951.x86_64.rpm                                                                                                                                             467 kB/s | 188 kB     00:00    
(41/68): proj-data-ca-8.2.1-6.fc36.noarch.rpm                                                                                                                                                          4.7 MB/s |  93 MB     00:19    
(42/68): proj-data-fo-8.2.1-6.fc36.noarch.rpm                                                                                                                                                           35 kB/s | 9.1 kB     00:00    
(43/68): netcdf-4.8.1-3.fc36.x86_64.rpm                                                                                                                                                                3.8 MB/s | 735 kB     00:00    
(44/68): proj-data-fr-8.2.1-6.fc36.noarch.rpm                                                                                                                                                          3.4 MB/s | 1.5 MB     00:00    
(45/68): proj-data-jp-8.2.1-6.fc36.noarch.rpm                                                                                                                                                          2.8 MB/s | 400 kB     00:00    
(46/68): proj-data-mx-8.2.1-6.fc36.noarch.rpm                                                                                                                                                          3.0 MB/s | 559 kB     00:00    
(47/68): proj-data-nc-8.2.1-6.fc36.noarch.rpm                                                                                                                                                          3.5 MB/s | 1.1 MB     00:00    
(48/68): proj-data-is-8.2.1-6.fc36.noarch.rpm                                                                                                                                                          4.6 MB/s | 5.3 MB     00:01    
(49/68): proj-data-nl-8.2.1-6.fc36.noarch.rpm                                                                                                                                                          3.7 MB/s | 1.1 MB     00:00    
(50/68): proj-data-no-8.2.1-6.fc36.noarch.rpm                                                                                                                                                          3.4 MB/s | 3.1 MB     00:00    
(51/68): proj-data-pt-8.2.1-6.fc36.noarch.rpm                                                                                                                                                          3.9 MB/s | 432 kB     00:00    
(52/68): proj-data-se-8.2.1-6.fc36.noarch.rpm                                                                                                                                                          3.9 MB/s | 2.2 MB     00:00    
(53/68): proj-data-sk-8.2.1-6.fc36.noarch.rpm                                                                                                                                                          3.1 MB/s | 1.2 MB     00:00    
(54/68): libkml-1.3.0-37.fc36.x86_64.rpm                                                                                                                                                               2.5 MB/s | 352 kB     00:00    
(55/68): R-CRAN-s2-1.1.0-1.fc36.copr4642124.x86_64.rpm                                                                                                                                                 2.8 MB/s | 2.0 MB     00:00    
(56/68): proj-data-nz-8.2.1-6.fc36.noarch.rpm                                                                                                                                                          4.0 MB/s |  13 MB     00:03    
(57/68): proj-data-uk-8.2.1-6.fc36.noarch.rpm                                                                                                                                                          3.6 MB/s | 4.7 MB     00:01    
(58/68): proj-data-za-8.2.1-6.fc36.noarch.rpm                                                                                                                                                          4.0 MB/s | 303 kB     00:00    
(59/68): R-CRAN-sf-1.0.8-1.fc36.copr4634685.x86_64.rpm                                                                                                                                                 2.7 MB/s | 3.0 MB     00:01    
(60/68): libgeotiff-1.7.1-2.fc36.x86_64.rpm                                                                                                                                                            848 kB/s | 106 kB     00:00    
(61/68): R-CRAN-units-0.8.0-1.fc36.copr4233471.x86_64.rpm                                                                                                                                              3.2 MB/s | 731 kB     00:00    
(62/68): R-CRAN-wk-0.6.0-1.fc36.copr4232516.x86_64.rpm                                                                                                                                                 661 kB/s | 434 kB     00:00    
(63/68): R-CRAN-DBI-1.1.3-1.fc36.copr4545985.noarch.rpm                                                                                                                                                3.5 MB/s | 744 kB     00:00    
(64/68): R-CRAN-MASS-7.3.58.1-1.fc36.copr4702184.x86_64.rpm                                                                                                                                            7.0 MB/s | 1.2 MB     00:00    
(65/68): cfitsio-4.0.0-2.fc36.x86_64.rpm                                                                                                                                                               1.6 MB/s | 595 kB     00:00    
(66/68): uriparser-0.9.6-4.fc36.x86_64.rpm                                                                                                                                                             1.9 MB/s |  61 kB     00:00    
(67/68): proj-data-au-8.2.1-6.fc36.noarch.rpm                                                                                                                                                          3.4 MB/s | 117 MB     00:34    
(68/68): proj-data-us-8.2.1-6.fc36.noarch.rpm                                                                                                                                                          7.3 MB/s | 223 MB     00:30    
  Preparing        :                                                                                                                                                                                                               1/1 
  Installing       : proj-data-8.2.1-6.fc36.noarch                                                                                                                                                                                1/68 
  Installing       : geos-3.10.2-4.fc36.x86_64                                                                                                                                                                                    2/68 
  Installing       : R-CRAN-Rcpp-1.0.9-1.fc36.copr4633910.x86_64                                                                                                                                                                  3/68 
  Installing       : hdf-libs-4.2.15-9.fc36.x86_64                                                                                                                                                                                4/68 
  Installing       : freexl-1.0.6-16.fc36.x86_64                                                                                                                                                                                  5/68 
  Installing       : librttopo-1.1.0-8.fc36.x86_64                                                                                                                                                                                6/68 
  Installing       : proj-data-at-8.2.1-6.fc36.noarch                                                                                                                                                                             7/68 
  Installing       : proj-data-au-8.2.1-6.fc36.noarch                                                                                                                                                                             8/68 
  Installing       : proj-data-be-8.2.1-6.fc36.noarch                                                                                                                                                                             9/68 
  Installing       : proj-data-br-8.2.1-6.fc36.noarch                                                                                                                                                                            10/68 
  Installing       : proj-data-ca-8.2.1-6.fc36.noarch                                                                                                                                                                            11/68 
  Installing       : proj-data-ch-8.2.1-6.fc36.noarch                                                                                                                                                                            12/68 
  Installing       : proj-data-de-8.2.1-6.fc36.noarch                                                                                                                                                                            13/68 
  Installing       : proj-data-dk-8.2.1-6.fc36.noarch                                                                                                                                                                            14/68 
  Installing       : proj-data-es-8.2.1-6.fc36.noarch                                                                                                                                                                            15/68 
  Installing       : proj-data-eur-8.2.1-6.fc36.noarch                                                                                                                                                                           16/68 
  Installing       : proj-data-fi-8.2.1-6.fc36.noarch                                                                                                                                                                            17/68 
  Installing       : proj-data-fo-8.2.1-6.fc36.noarch                                                                                                                                                                            18/68 
  Installing       : proj-data-fr-8.2.1-6.fc36.noarch                                                                                                                                                                            19/68 
  Installing       : proj-data-is-8.2.1-6.fc36.noarch                                                                                                                                                                            20/68 
  Installing       : proj-data-jp-8.2.1-6.fc36.noarch                                                                                                                                                                            21/68 
  Installing       : proj-data-mx-8.2.1-6.fc36.noarch                                                                                                                                                                            22/68 
  Installing       : proj-data-nc-8.2.1-6.fc36.noarch                                                                                                                                                                            23/68 
  Installing       : proj-data-nl-8.2.1-6.fc36.noarch                                                                                                                                                                            24/68 
  Installing       : proj-data-no-8.2.1-6.fc36.noarch                                                                                                                                                                            25/68 
  Installing       : proj-data-nz-8.2.1-6.fc36.noarch                                                                                                                                                                            26/68 
  Installing       : proj-data-pt-8.2.1-6.fc36.noarch                                                                                                                                                                            27/68 
  Installing       : proj-data-se-8.2.1-6.fc36.noarch                                                                                                                                                                            28/68 
  Installing       : proj-data-sk-8.2.1-6.fc36.noarch                                                                                                                                                                            29/68 
  Installing       : proj-data-uk-8.2.1-6.fc36.noarch                                                                                                                                                                            30/68 
  Installing       : proj-data-us-8.2.1-6.fc36.noarch                                                                                                                                                                            31/68 
  Installing       : proj-data-za-8.2.1-6.fc36.noarch                                                                                                                                                                            32/68 
  Installing       : proj-8.2.1-6.fc36.x86_64                                                                                                                                                                                    33/68 
  Installing       : libgeotiff-1.7.1-2.fc36.x86_64                                                                                                                                                                              34/68 
  Installing       : mariadb-connector-c-config-3.2.7-1.fc36.noarch                                                                                                                                                              35/68 
  Installing       : mariadb-connector-c-3.2.7-1.fc36.x86_64                                                                                                                                                                     36/68 
  Installing       : xerces-c-3.2.3-6.fc36.x86_64                                                                                                                                                                                37/68 
  Installing       : uriparser-0.9.6-4.fc36.x86_64                                                                                                                                                                               38/68 
  Installing       : libkml-1.3.0-37.fc36.x86_64                                                                                                                                                                                 39/68 
  Installing       : unixODBC-2.3.9-5.fc36.x86_64                                                                                                                                                                                40/68 
  Installing       : udunits2-2.2.28-5.fc36.x86_64                                                                                                                                                                               41/68 
  Installing       : R-CRAN-units-0.8.0-1.fc36.copr4233471.x86_64                                                                                                                                                                42/68 
  Installing       : ogdi-4.1.0-7.fc36.x86_64                                                                                                                                                                                    43/68 
  Installing       : minizip-3.0.2-6.fc36.x86_64                                                                                                                                                                                 44/68 
  Installing       : libspatialite-5.0.1-12.fc36.x86_64                                                                                                                                                                          45/68 
  Installing       : libpq-14.1-2.fc36.x86_64                                                                                                                                                                                    46/68 
  Installing       : libgta-1.2.1-7.fc36.x86_64                                                                                                                                                                                  47/68 
  Installing       : libdap-3.20.9-2.fc36.x86_64                                                                                                                                                                                 48/68 
  Installing       : libaec-1.0.6-2.fc36.x86_64                                                                                                                                                                                  49/68 
  Installing       : hdf5-1.12.1-5.fc36.x86_64                                                                                                                                                                                   50/68 
  Installing       : netcdf-4.8.1-3.fc36.x86_64                                                                                                                                                                                  51/68 
  Installing       : jasper-libs-2.0.33-2.fc36.x86_64                                                                                                                                                                            52/68 
  Installing       : cfitsio-4.0.0-2.fc36.x86_64                                                                                                                                                                                 53/68 
  Installing       : arpack-3.8.0-4.fc36.x86_64                                                                                                                                                                                  54/68 
  Installing       : SuperLU-5.3.0-2.fc36.x86_64                                                                                                                                                                                 55/68 
  Installing       : armadillo-10.8.2-1.fc36.x86_64                                                                                                                                                                              56/68 
  Installing       : gdal-libs-3.4.3-1.fc36.x86_64                                                                                                                                                                               57/68 
  Installing       : R-CRAN-wk-0.6.0-1.fc36.copr4232516.x86_64                                                                                                                                                                   58/68 
  Installing       : R-CRAN-s2-1.1.0-1.fc36.copr4642124.x86_64                                                                                                                                                                   59/68 
  Installing       : R-CRAN-proxy-0.4.27-1.fc36.copr4508951.x86_64                                                                                                                                                               60/68 
  Installing       : R-CRAN-magrittr-2.0.3-1.fc36.copr4227992.x86_64                                                                                                                                                             61/68 
  Installing       : R-CRAN-MASS-7.3.58.1-1.fc36.copr4702184.x86_64                                                                                                                                                              62/68 
  Installing       : R-CRAN-class-7.3.20-1.fc36.copr4235897.x86_64                                                                                                                                                               63/68 
  Installing       : R-CRAN-e1071-1.7.11-1.fc36.copr4504876.x86_64                                                                                                                                                               64/68 
  Installing       : R-CRAN-KernSmooth-2.23.20-1.fc36.copr4232710.x86_64                                                                                                                                                         65/68 
  Installing       : R-CRAN-classInt-0.4.7-1.fc36.copr4510456.x86_64                                                                                                                                                             66/68 
  Installing       : R-CRAN-DBI-1.1.3-1.fc36.copr4545985.noarch                                                                                                                                                                  67/68 
  Installing       : R-CRAN-sf-1.0.8-1.fc36.copr4634685.x86_64                                                                                                                                                                   68/68 
  Running scriptlet: R-CRAN-sf-1.0.8-1.fc36.copr4634685.x86_64                                                                                                                                                                   68/68 
  Verifying        : R-CRAN-DBI-1.1.3-1.fc36.copr4545985.noarch                                                                                                                                                                   1/68 
  Verifying        : R-CRAN-KernSmooth-2.23.20-1.fc36.copr4232710.x86_64                                                                                                                                                          2/68 
  Verifying        : R-CRAN-MASS-7.3.58.1-1.fc36.copr4702184.x86_64                                                                                                                                                               3/68 
  Verifying        : R-CRAN-Rcpp-1.0.9-1.fc36.copr4633910.x86_64                                                                                                                                                                  4/68 
  Verifying        : R-CRAN-class-7.3.20-1.fc36.copr4235897.x86_64                                                                                                                                                                5/68 
  Verifying        : R-CRAN-classInt-0.4.7-1.fc36.copr4510456.x86_64                                                                                                                                                              6/68 
  Verifying        : R-CRAN-e1071-1.7.11-1.fc36.copr4504876.x86_64                                                                                                                                                                7/68 
  Verifying        : R-CRAN-magrittr-2.0.3-1.fc36.copr4227992.x86_64                                                                                                                                                              8/68 
  Verifying        : R-CRAN-proxy-0.4.27-1.fc36.copr4508951.x86_64                                                                                                                                                                9/68 
  Verifying        : R-CRAN-s2-1.1.0-1.fc36.copr4642124.x86_64                                                                                                                                                                   10/68 
  Verifying        : R-CRAN-sf-1.0.8-1.fc36.copr4634685.x86_64                                                                                                                                                                   11/68 
  Verifying        : R-CRAN-units-0.8.0-1.fc36.copr4233471.x86_64                                                                                                                                                                12/68 
  Verifying        : R-CRAN-wk-0.6.0-1.fc36.copr4232516.x86_64                                                                                                                                                                   13/68 
  Verifying        : SuperLU-5.3.0-2.fc36.x86_64                                                                                                                                                                                 14/68 
  Verifying        : armadillo-10.8.2-1.fc36.x86_64                                                                                                                                                                              15/68 
  Verifying        : arpack-3.8.0-4.fc36.x86_64                                                                                                                                                                                  16/68 
  Verifying        : cfitsio-4.0.0-2.fc36.x86_64                                                                                                                                                                                 17/68 
  Verifying        : freexl-1.0.6-16.fc36.x86_64                                                                                                                                                                                 18/68 
  Verifying        : geos-3.10.2-4.fc36.x86_64                                                                                                                                                                                   19/68 
  Verifying        : hdf-libs-4.2.15-9.fc36.x86_64                                                                                                                                                                               20/68 
  Verifying        : hdf5-1.12.1-5.fc36.x86_64                                                                                                                                                                                   21/68 
  Verifying        : jasper-libs-2.0.33-2.fc36.x86_64                                                                                                                                                                            22/68 
  Verifying        : libaec-1.0.6-2.fc36.x86_64                                                                                                                                                                                  23/68 
  Verifying        : libdap-3.20.9-2.fc36.x86_64                                                                                                                                                                                 24/68 
  Verifying        : libgta-1.2.1-7.fc36.x86_64                                                                                                                                                                                  25/68 
  Verifying        : libkml-1.3.0-37.fc36.x86_64                                                                                                                                                                                 26/68 
  Verifying        : libpq-14.1-2.fc36.x86_64                                                                                                                                                                                    27/68 
  Verifying        : librttopo-1.1.0-8.fc36.x86_64                                                                                                                                                                               28/68 
  Verifying        : libspatialite-5.0.1-12.fc36.x86_64                                                                                                                                                                          29/68 
  Verifying        : minizip-3.0.2-6.fc36.x86_64                                                                                                                                                                                 30/68 
  Verifying        : netcdf-4.8.1-3.fc36.x86_64                                                                                                                                                                                  31/68 
  Verifying        : ogdi-4.1.0-7.fc36.x86_64                                                                                                                                                                                    32/68 
  Verifying        : proj-8.2.1-6.fc36.x86_64                                                                                                                                                                                    33/68 
  Verifying        : proj-data-8.2.1-6.fc36.noarch                                                                                                                                                                               34/68 
  Verifying        : proj-data-at-8.2.1-6.fc36.noarch                                                                                                                                                                            35/68 
  Verifying        : proj-data-au-8.2.1-6.fc36.noarch                                                                                                                                                                            36/68 
  Verifying        : proj-data-be-8.2.1-6.fc36.noarch                                                                                                                                                                            37/68 
  Verifying        : proj-data-br-8.2.1-6.fc36.noarch                                                                                                                                                                            38/68 
  Verifying        : proj-data-ca-8.2.1-6.fc36.noarch                                                                                                                                                                            39/68 
  Verifying        : proj-data-ch-8.2.1-6.fc36.noarch                                                                                                                                                                            40/68 
  Verifying        : proj-data-de-8.2.1-6.fc36.noarch                                                                                                                                                                            41/68 
  Verifying        : proj-data-dk-8.2.1-6.fc36.noarch                                                                                                                                                                            42/68 
  Verifying        : proj-data-es-8.2.1-6.fc36.noarch                                                                                                                                                                            43/68 
  Verifying        : proj-data-eur-8.2.1-6.fc36.noarch                                                                                                                                                                           44/68 
  Verifying        : proj-data-fi-8.2.1-6.fc36.noarch                                                                                                                                                                            45/68 
  Verifying        : proj-data-fo-8.2.1-6.fc36.noarch                                                                                                                                                                            46/68 
  Verifying        : proj-data-fr-8.2.1-6.fc36.noarch                                                                                                                                                                            47/68 
  Verifying        : proj-data-is-8.2.1-6.fc36.noarch                                                                                                                                                                            48/68 
  Verifying        : proj-data-jp-8.2.1-6.fc36.noarch                                                                                                                                                                            49/68 
  Verifying        : proj-data-mx-8.2.1-6.fc36.noarch                                                                                                                                                                            50/68 
  Verifying        : proj-data-nc-8.2.1-6.fc36.noarch                                                                                                                                                                            51/68 
  Verifying        : proj-data-nl-8.2.1-6.fc36.noarch                                                                                                                                                                            52/68 
  Verifying        : proj-data-no-8.2.1-6.fc36.noarch                                                                                                                                                                            53/68 
  Verifying        : proj-data-nz-8.2.1-6.fc36.noarch                                                                                                                                                                            54/68 
  Verifying        : proj-data-pt-8.2.1-6.fc36.noarch                                                                                                                                                                            55/68 
  Verifying        : proj-data-se-8.2.1-6.fc36.noarch                                                                                                                                                                            56/68 
  Verifying        : proj-data-sk-8.2.1-6.fc36.noarch                                                                                                                                                                            57/68 
  Verifying        : proj-data-uk-8.2.1-6.fc36.noarch                                                                                                                                                                            58/68 
  Verifying        : proj-data-us-8.2.1-6.fc36.noarch                                                                                                                                                                            59/68 
  Verifying        : proj-data-za-8.2.1-6.fc36.noarch                                                                                                                                                                            60/68 
  Verifying        : udunits2-2.2.28-5.fc36.x86_64                                                                                                                                                                               61/68 
  Verifying        : unixODBC-2.3.9-5.fc36.x86_64                                                                                                                                                                                62/68 
  Verifying        : uriparser-0.9.6-4.fc36.x86_64                                                                                                                                                                               63/68 
  Verifying        : xerces-c-3.2.3-6.fc36.x86_64                                                                                                                                                                                64/68 
  Verifying        : gdal-libs-3.4.3-1.fc36.x86_64                                                                                                                                                                               65/68 
  Verifying        : libgeotiff-1.7.1-2.fc36.x86_64                                                                                                                                                                              66/68 
  Verifying        : mariadb-connector-c-3.2.7-1.fc36.x86_64                                                                                                                                                                     67/68 
  Verifying        : mariadb-connector-c-config-3.2.7-1.fc36.noarch                                                                                                                                                              68/68 
> library(sf)
Linking to GEOS 3.10.2, GDAL 3.4.3, PROJ 8.2.1; sf_use_s2() is TRUE
```