### PR TITLE
add fedora-arm64 dockerfile

### DIFF
--- a/fedora-arm64/Dockerfile
+++ b/fedora-arm64/Dockerfile
@@ -1,0 +1,35 @@
+FROM fedora:36
+
+LABEL org.label-schema.license="GPL-2.0" \
+      org.label-schema.vcs-url="https://github.com/rocker-org/rocker"
+
+RUN echo "install_weak_deps=False" >> /etc/dnf/dnf.conf \
+    && dnf -y upgrade && dnf -y install R sudo
+
+## Note, the COPR repo is amd64 only, so we cannot use it here.
+RUN dnf -y install python3-dnf python3-dbus python3-gobject
+
+RUN echo "options(repos='https://cloud.r-project.org')" \
+	> /usr/lib64/R/etc/Rprofile.site \
+    && Rscript -e 'install.packages(c("bspm","littler"))' \
+    && echo "bspm::enable()" >> /usr/lib64/R/etc/Rprofile.site \
+    && echo "options(bspm.sudo=TRUE)" >> /usr/lib64/R/etc/Rprofile.site
+
+RUN useradd -m docker \
+    && echo "docker ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/docker-user \
+    && chmod 0440 /etc/sudoers.d/docker-user \
+    && mkdir -p /usr/local/lib/R/site-library \
+    && chown 1000:1000 /usr/local/lib/R/site-library
+
+RUN ln -s /usr/lib64/R/library/littler/bin/r /usr/local/bin/r \
+    && ln -s /usr/lib64/R/library/littler/examples/install.r \
+        /usr/local/bin/install.r \
+    && ln -s /usr/lib64/R/library/littler/examples/install2.r \
+        /usr/local/bin/install2.r \
+    && ln -s /usr/lib64/R/library/littler/examples/installGithub.r \
+        /usr/local/bin/installGithub.r \
+    && ln -s /usr/lib64/R/library/littler/examples/testInstalled.r \
+        /usr/local/bin/testInstalled.r \
+    && install.r remotes
+
+CMD ["bash"]


### PR DESCRIPTION
Create a Fedora image for use on arm64 devices (e.g. Raspberry Pi, Oracle Cloud).
This installs bspm manually, as the COPR repo usually used in Fedora installation is for amd64 only.

Test output (Raspberry Pi 4B):
```shell
niklas@gojiberry:~/tmp/bspm/fedora-arm64 $ docker run --rm -it c07e
[root@975503b3f9f7 /] R

R version 4.1.3 (2022-03-10) -- "One Push-Up"
Copyright (C) 2022 The R Foundation for Statistical Computing
Platform: aarch64-redhat-linux-gnu (64-bit)

R is free software and comes with ABSOLUTELY NO WARRANTY.
You are welcome to redistribute it under certain conditions.
Type 'license()' or 'licence()' for distribution details.

R is a collaborative project with many contributors.
Type 'contributors()' for more information and
'citation()' on how to cite R or R packages in publications.

Type 'demo()' for some demos, 'help()' for on-line help, or
'help.start()' for an HTML browser interface to help.
Type 'q()' to quit R.

Loading required package: utils
Tracing function "install.packages" in package "utils"
> install.packages("units")
Install system packages as root...
Fedora 36 - aarch64                                                                                                                                                                                     54 kB/s |  17 kB     00:00    
Fedora 36 openh264 (From Cisco) - aarch64                                                                                                                                                              5.6 kB/s | 990  B     00:00    
Fedora Modular 36 - aarch64                                                                                                                                                                             86 kB/s |  17 kB     00:00    
Fedora 36 - aarch64 - Updates                                                                                                                                                                           32 kB/s |  14 kB     00:00    
Fedora Modular 36 - aarch64 - Updates                                                                                                                                                                   29 kB/s |  16 kB     00:00    
(1/4): R-xml2-1.3.2-8.fc36.aarch64.rpm                                                                                                                                                                 492 kB/s | 254 kB     00:00    
(2/4): udunits2-2.2.28-5.fc36.aarch64.rpm                                                                                                                                                              1.0 MB/s | 630 kB     00:00    
(3/4): R-units-0.8.0-1.fc36.aarch64.rpm                                                                                                                                                                1.8 MB/s | 729 kB     00:00    
(4/4): R-Rcpp-1.0.9-1.fc36.aarch64.rpm                                                                                                                                                                 1.6 MB/s | 1.6 MB     00:00    
  Preparing        :                                                                                                                                                                                                               1/1 
  Installing       : R-Rcpp-1.0.9-1.fc36.aarch64                                                                                                                                                                                   1/4 
  Installing       : udunits2-2.2.28-5.fc36.aarch64                                                                                                                                                                                2/4 
  Installing       : R-xml2-1.3.2-8.fc36.aarch64                                                                                                                                                                                   3/4 
  Installing       : R-units-0.8.0-1.fc36.aarch64                                                                                                                                                                                  4/4 
  Running scriptlet: R-units-0.8.0-1.fc36.aarch64                                                                                                                                                                                  4/4 
  Verifying        : R-units-0.8.0-1.fc36.aarch64                                                                                                                                                                                  1/4 
  Verifying        : R-xml2-1.3.2-8.fc36.aarch64                                                                                                                                                                                   2/4 
  Verifying        : udunits2-2.2.28-5.fc36.aarch64                                                                                                                                                                                3/4 
  Verifying        : R-Rcpp-1.0.9-1.fc36.aarch64                                                                                                                                                                                   4/4 
> install.packages("ggplot2")
Install system packages as root...
Fedora 36 - aarch64                                                                                                                                                                                    120 kB/s |  17 kB     00:00    
Fedora 36 openh264 (From Cisco) - aarch64                                                                                                                                                              5.2 kB/s | 990  B     00:00    
Fedora Modular 36 - aarch64                                                                                                                                                                             86 kB/s |  17 kB     00:00    
Fedora 36 - aarch64 - Updates                                                                                                                                                                           73 kB/s |  14 kB     00:00    
Fedora Modular 36 - aarch64 - Updates                                                                                                                                                                   28 kB/s |  16 kB     00:00    
(1/26): R-magrittr-2.0.1-4.fc36.aarch64.rpm                                                                                                                                                            561 kB/s | 218 kB     00:00    
(2/26): R-crayon-1.4.2-2.fc36.noarch.rpm                                                                                                                                                               398 kB/s | 178 kB     00:00    
(3/26): R-munsell-0.5.0-12.fc36.noarch.rpm                                                                                                                                                             2.4 MB/s | 251 kB     00:00    
(4/26): R-digest-0.6.27-4.fc36.aarch64.rpm                                                                                                                                                             2.1 MB/s | 204 kB     00:00    
(5/26): R-ellipsis-0.3.2-3.fc36.aarch64.rpm                                                                                                                                                            1.1 MB/s |  49 kB     00:00    
(6/26): R-fansi-0.5.0-3.fc36.aarch64.rpm                                                                                                                                                               1.7 MB/s | 229 kB     00:00    
(7/26): R-tibble-3.1.4-2.fc36~bootstrap.aarch64.rpm                                                                                                                                                    2.0 MB/s | 763 kB     00:00    
(8/26): R-farver-2.1.0-4.fc36.aarch64.rpm                                                                                                                                                              2.9 MB/s | 1.4 MB     00:00    
(9/26): R-pillar-1.6.2-2.fc36~bootstrap.noarch.rpm                                                                                                                                                     1.9 MB/s | 986 kB     00:00    
(10/26): R-utf8-1.2.1-5.fc36.aarch64.rpm                                                                                                                                                               1.5 MB/s | 151 kB     00:00    
(11/26): R-pkgconfig-2.0.3-9.fc36.noarch.rpm                                                                                                                                                           609 kB/s |  30 kB     00:00    
(12/26): R-vctrs-0.3.8-4.fc36.aarch64.rpm                                                                                                                                                              2.0 MB/s | 1.1 MB     00:00    
(13/26): R-colorspace-2.0.1-3.fc36.aarch64.rpm                                                                                                                                                         1.2 MB/s | 2.4 MB     00:01    
(14/26): R-R6-2.5.1-2.fc36.noarch.rpm                                                                                                                                                                  722 kB/s |  96 kB     00:00    
(15/26): R-viridisLite-0.4.0-5.fc36.noarch.rpm                                                                                                                                                         2.0 MB/s | 1.2 MB     00:00    
(16/26): R-RColorBrewer-1.1.2-11.fc36.noarch.rpm                                                                                                                                                       659 kB/s |  65 kB     00:00    
(17/26): R-withr-2.4.3-1.fc36.noarch.rpm                                                                                                                                                               2.3 MB/s | 244 kB     00:00    
(18/26): R-glue-1.4.2-6.fc36.aarch64.rpm                                                                                                                                                               1.7 MB/s | 151 kB     00:00    
(19/26): R-gtable-0.3.0-11.fc36.noarch.rpm                                                                                                                                                             1.7 MB/s | 401 kB     00:00    
(20/26): R-rlang-0.4.11-3.fc35.aarch64.rpm                                                                                                                                                             1.2 MB/s | 1.2 MB     00:00    
(21/26): R-ggplot2-3.3.3-5.fc36.noarch.rpm                                                                                                                                                             3.1 MB/s | 4.0 MB     00:01    
(22/26): R-labeling-0.4.2-5.fc36.noarch.rpm                                                                                                                                                            305 kB/s |  77 kB     00:00    
(23/26): R-isoband-0.2.4-4.fc36~bootstrap.aarch64.rpm                                                                                                                                                  1.8 MB/s | 2.0 MB     00:01    
(24/26): R-lifecycle-1.0.0-4.fc36.noarch.rpm                                                                                                                                                           867 kB/s | 104 kB     00:00    
(25/26): R-scales-1.1.1-7.fc36.noarch.rpm                                                                                                                                                              2.7 MB/s | 582 kB     00:00    
(26/26): R-cli-2.5.0-3.fc35.noarch.rpm                                                                                                                                                                 4.3 MB/s | 580 kB     00:00    
  Preparing        :                                                                                                                                                                                                               1/1 
  Installing       : R-withr-2.4.3-1.fc36.noarch                                                                                                                                                                                  1/26 
  Installing       : R-crayon-1.4.2-2.fc36.noarch                                                                                                                                                                                 2/26 
  Installing       : R-RColorBrewer-1.1.2-11.fc36.noarch                                                                                                                                                                          3/26 
  Installing       : R-fansi-0.5.0-3.fc36.aarch64                                                                                                                                                                                 4/26 
  Installing       : R-pkgconfig-2.0.3-9.fc36.noarch                                                                                                                                                                              5/26 
  Installing       : R-labeling-0.4.2-5.fc36.noarch                                                                                                                                                                               6/26 
  Installing       : R-farver-2.1.0-4.fc36.aarch64                                                                                                                                                                                7/26 
  Installing       : R-digest-0.6.27-4.fc36.aarch64                                                                                                                                                                               8/26 
  Installing       : R-R6-2.5.1-2.fc36.noarch                                                                                                                                                                                     9/26 
  Installing       : R-colorspace-2.0.1-3.fc36.aarch64                                                                                                                                                                           10/26 
  Installing       : R-cli-2.5.0-3.fc35.noarch                                                                                                                                                                                   11/26 
  Installing       : R-ellipsis-0.3.2-3.fc36.aarch64                                                                                                                                                                             12/26 
  Installing       : R-magrittr-2.0.1-4.fc36.aarch64                                                                                                                                                                             13/26 
  Installing       : R-utf8-1.2.1-5.fc36.aarch64                                                                                                                                                                                 14/26 
  Installing       : R-rlang-0.4.11-3.fc35.aarch64                                                                                                                                                                               15/26 
  Installing       : R-glue-1.4.2-6.fc36.aarch64                                                                                                                                                                                 16/26 
  Installing       : R-gtable-0.3.0-11.fc36.noarch                                                                                                                                                                               17/26 
  Installing       : R-isoband-0.2.4-4.fc36~bootstrap.aarch64                                                                                                                                                                    18/26 
  Installing       : R-munsell-0.5.0-12.fc36.noarch                                                                                                                                                                              19/26 
  Installing       : R-viridisLite-0.4.0-5.fc36.noarch                                                                                                                                                                           20/26 
  Installing       : R-ggplot2-3.3.3-5.fc36.noarch                                                                                                                                                                               21/26 
  Installing       : R-lifecycle-1.0.0-4.fc36.noarch                                                                                                                                                                             22/26 
  Installing       : R-scales-1.1.1-7.fc36.noarch                                                                                                                                                                                23/26 
  Installing       : R-tibble-3.1.4-2.fc36~bootstrap.aarch64                                                                                                                                                                     24/26 
  Installing       : R-vctrs-0.3.8-4.fc36.aarch64                                                                                                                                                                                25/26 
  Installing       : R-pillar-1.6.2-2.fc36~bootstrap.noarch                                                                                                                                                                      26/26 
  Running scriptlet: R-pillar-1.6.2-2.fc36~bootstrap.noarch                                                                                                                                                                      26/26 
  Verifying        : R-R6-2.5.1-2.fc36.noarch                                                                                                                                                                                     1/26 
  Verifying        : R-RColorBrewer-1.1.2-11.fc36.noarch                                                                                                                                                                          2/26 
  Verifying        : R-cli-2.5.0-3.fc35.noarch                                                                                                                                                                                    3/26 
  Verifying        : R-colorspace-2.0.1-3.fc36.aarch64                                                                                                                                                                            4/26 
  Verifying        : R-crayon-1.4.2-2.fc36.noarch                                                                                                                                                                                 5/26 
  Verifying        : R-digest-0.6.27-4.fc36.aarch64                                                                                                                                                                               6/26 
  Verifying        : R-ellipsis-0.3.2-3.fc36.aarch64                                                                                                                                                                              7/26 
  Verifying        : R-fansi-0.5.0-3.fc36.aarch64                                                                                                                                                                                 8/26 
  Verifying        : R-farver-2.1.0-4.fc36.aarch64                                                                                                                                                                                9/26 
  Verifying        : R-ggplot2-3.3.3-5.fc36.noarch                                                                                                                                                                               10/26 
  Verifying        : R-glue-1.4.2-6.fc36.aarch64                                                                                                                                                                                 11/26 
  Verifying        : R-gtable-0.3.0-11.fc36.noarch                                                                                                                                                                               12/26 
  Verifying        : R-isoband-0.2.4-4.fc36~bootstrap.aarch64                                                                                                                                                                    13/26 
  Verifying        : R-labeling-0.4.2-5.fc36.noarch                                                                                                                                                                              14/26 
  Verifying        : R-lifecycle-1.0.0-4.fc36.noarch                                                                                                                                                                             15/26 
  Verifying        : R-magrittr-2.0.1-4.fc36.aarch64                                                                                                                                                                             16/26 
  Verifying        : R-munsell-0.5.0-12.fc36.noarch                                                                                                                                                                              17/26 
  Verifying        : R-pillar-1.6.2-2.fc36~bootstrap.noarch                                                                                                                                                                      18/26 
  Verifying        : R-pkgconfig-2.0.3-9.fc36.noarch                                                                                                                                                                             19/26 
  Verifying        : R-rlang-0.4.11-3.fc35.aarch64                                                                                                                                                                               20/26 
  Verifying        : R-scales-1.1.1-7.fc36.noarch                                                                                                                                                                                21/26 
  Verifying        : R-tibble-3.1.4-2.fc36~bootstrap.aarch64                                                                                                                                                                     22/26 
  Verifying        : R-utf8-1.2.1-5.fc36.aarch64                                                                                                                                                                                 23/26 
  Verifying        : R-vctrs-0.3.8-4.fc36.aarch64                                                                                                                                                                                24/26 
  Verifying        : R-viridisLite-0.4.0-5.fc36.noarch                                                                                                                                                                           25/26 
  Verifying        : R-withr-2.4.3-1.fc36.noarch                                                                                                                                                                                 26/26 
> library("ggplot2")
Want to understand how all the pieces fit together? Read R for Data
Science: https://r4ds.had.co.nz/
> library("units")
udunits database from /usr/share/udunits/udunits2.xml
```