### PR TITLE
Enable fast mode with bspm >= 0.5.0

### DIFF
--- a/focal/Dockerfile
+++ b/focal/Dockerfile
@@ -13,7 +13,6 @@ RUN add-apt-repository --yes "ppa:edd/r-4.0" \
 	&& apt-get install -y --no-install-recommends \
                 r-cran-bspm \
         && echo "suppressMessages(bspm::enable())" >> /etc/R/Rprofile.site \
-        && echo "options(pkgType=\"binary-source\")" >> /etc/R/Rprofile.site \
         && echo 'APT::Install-Recommends "false";' > /etc/apt/apt.conf.d/90local-no-recommends \
         && chgrp 1000 /usr/local/lib/R/site-library \
         && install.r remotes

--- a/focal/Dockerfile
+++ b/focal/Dockerfile
@@ -13,6 +13,7 @@ RUN add-apt-repository --yes "ppa:edd/r-4.0" \
 	&& apt-get install -y --no-install-recommends \
                 r-cran-bspm \
         && echo "suppressMessages(bspm::enable())" >> /etc/R/Rprofile.site \
+        && echo "options(bspm.version.check=FALSE)" >> /etc/R/Rprofile.site \
         && echo 'APT::Install-Recommends "false";' > /etc/apt/apt.conf.d/90local-no-recommends \
         && chgrp 1000 /usr/local/lib/R/site-library \
         && install.r remotes

--- a/jammy/Dockerfile
+++ b/jammy/Dockerfile
@@ -12,6 +12,7 @@ LABEL org.label-schema.license="GPL-2.0" \
 RUN apt update -qq \
         && install.r bspm \
         && echo "suppressMessages(bspm::enable())" >> /etc/R/Rprofile.site \
+        && echo "options(bspm.version.check=FALSE)" >> /etc/R/Rprofile.site \
         && echo 'APT::Install-Recommends "false";' > /etc/apt/apt.conf.d/90local-no-recommends \
         && chgrp 1000 /usr/local/lib/R/site-library \
         && install.r remotes

--- a/jammy/Dockerfile
+++ b/jammy/Dockerfile
@@ -12,7 +12,6 @@ LABEL org.label-schema.license="GPL-2.0" \
 RUN apt update -qq \
         && install.r bspm \
         && echo "suppressMessages(bspm::enable())" >> /etc/R/Rprofile.site \
-        && echo "options(pkgType=\"binary-source\")" >> /etc/R/Rprofile.site \
         && echo 'APT::Install-Recommends "false";' > /etc/apt/apt.conf.d/90local-no-recommends \
         && chgrp 1000 /usr/local/lib/R/site-library \
         && install.r remotes


### PR DESCRIPTION
After a rebuild of both r-bspm and r2u images with current CRAN bspm version, this fixes eddelbuettel/r-ci/issues/10.

If the new option `bspm.fast` is required, the current master version may be used, but it shouldn't be enabled by default in r-bspm or r2u, or it will break r-ci.