### PR TITLE
update fedora image version

### DIFF
--- a/fedora/Dockerfile
+++ b/fedora/Dockerfile
@@ -1,4 +1,4 @@
-FROM fedora:37
+FROM fedora:38
 
 LABEL org.label-schema.license="GPL-2.0" \
       org.label-schema.vcs-url="https://github.com/rocker-org/rocker" \
@@ -12,7 +12,6 @@ RUN echo "install_weak_deps=False" >> /etc/dnf/dnf.conf \
 # enable copr
 RUN dnf -y install 'dnf-command(copr)' \
     && dnf -y copr enable iucar/cran \
-    && sed -ie '/nodocs/d' /etc/dnf/dnf.conf \
     && dnf -y install R-CoprManager \
     && dnf -y clean all \
     && echo "options(repos='https://cloud.r-project.org')" > \


### PR DESCRIPTION
Updating to F38, released last week. You'll note that, after my latest spec cleanup for R 4.3.0, the image size is now on par with the ones from our fellow Debian/Ubuntu colleagues. ;-)